### PR TITLE
vendor/citrus: sepolicy: remove qemu_hw_mainkeys_prop

### DIFF
--- a/sepolicy/qcom/common/platform_app.te
+++ b/sepolicy/qcom/common/platform_app.te
@@ -1,1 +1,0 @@
-get_prop(platform_app, qemu_hw_mainkeys_prop)


### PR DESCRIPTION
* label has been removed on P qcom/common, if necesarry will be
  added back later

Signed-off-by: Adarsh-MR <adarshmr1998@gmail.com>